### PR TITLE
Add read sort order to search

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -864,6 +864,20 @@ class Search
       else
         posts = posts.order("posts.like_count DESC")
       end
+    elsif @order == :read
+      if @guardian.user
+        posts = posts.joins(<<~SQL)
+          LEFT JOIN topic_users tu ON
+            tu.topic_id = posts.topic_id AND
+            tu.user_id = #{@guardian.user.id}
+        SQL
+
+        if aggregate_search
+          posts = posts.order("MAX(tu.last_visited_at) DESC NULLS LAST")
+        else
+          posts = posts.reorder("tu.last_visited_at DESC NULLS LAST")
+        end
+      end
     elsif allow_relevance_search
       posts = sort_by_relevance(posts, type_filter: type_filter, aggregate_search: aggregate_search)
     end

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -2315,6 +2315,28 @@ RSpec.describe Search do
       )
     end
 
+    it "can order by read" do
+      user = Fabricate(:user)
+
+      post1 = nil
+      freeze_time 2.hours.ago do
+        post1 = Fabricate(:post, raw: "Topic")
+        TopicUser.update_last_read(user, post1.topic.id, 1, 1, 0)
+      end
+
+      post2 = nil
+      freeze_time 1.hour.ago do
+        post2 = Fabricate(:post, raw: "Topic")
+        TopicUser.update_last_read(user, post2.topic.id, 1, 1, 0)
+      end
+
+      post3 = Fabricate(:post, raw: "Topic")
+
+      expect(
+        Search.execute("Topic order:read", guardian: Guardian.new(user)).posts.map(&:id),
+      ).to eq([post2.id, post1.id, post3.id])
+    end
+
     it "can search for terms with dots" do
       post = Fabricate(:post, raw: "Will.2000 Will.Bob.Bill...")
       expect(Search.execute("bill").posts.map(&:id)).to eq([post.id])


### PR DESCRIPTION
## Summary
- sort search results by last visited time using `order:read`
- test read sort order

## Testing
- `bundle exec rubocop lib/search.rb spec/lib/search_spec.rb`
- `bundle exec rspec spec/lib/search_spec.rb:2318`


------
https://chatgpt.com/codex/tasks/task_b_685c8a0ebb1c8324930ad0af60159736