### PR TITLE
Add flexible poll support

### DIFF
--- a/plugins/poll/app/serializers/poll_serializer.rb
+++ b/plugins/poll/app/serializers/poll_serializer.rb
@@ -16,6 +16,7 @@ class PollSerializer < ApplicationSerializer
              :preloaded_voters,
              :chart_type,
              :groups,
+             :flexible,
              :title,
              :ranked_choice_outcome
 
@@ -41,6 +42,10 @@ class PollSerializer < ApplicationSerializer
 
   def include_groups?
     groups.present?
+  end
+
+  def include_flexible?
+    object.flexible?
   end
 
   def options

--- a/plugins/poll/db/migrate/20250626012811_add_flexible_to_polls.rb
+++ b/plugins/poll/db/migrate/20250626012811_add_flexible_to_polls.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddFlexibleToPolls < ActiveRecord::Migration[7.0]
+  def change
+    add_column :polls, :flexible, :boolean, null: false, default: false
+  end
+end

--- a/plugins/poll/lib/poll.rb
+++ b/plugins/poll/lib/poll.rb
@@ -402,6 +402,7 @@ class DiscoursePoll::Poll
         step: poll["step"],
         chart_type: poll["charttype"] || "bar",
         groups: poll["groups"],
+        flexible: poll["flexible"] == "true",
       )
 
     poll["options"].each do |option|
@@ -430,7 +431,11 @@ class DiscoursePoll::Poll
       .HTML5(cooked)
       .css("div.poll")
       .map do |p|
-        poll = { "options" => [], "name" => DiscoursePoll::DEFAULT_POLL_NAME }
+        poll = {
+          "options" => [],
+          "name" => DiscoursePoll::DEFAULT_POLL_NAME,
+          "flexible" => "false",
+        }
 
         # attributes
         p.attributes.values.each do |attribute|


### PR DESCRIPTION
## Summary
- allow polls to be flagged as `flexible`
- preserve votes when adding or removing options on flexible polls
- expose `flexible` attribute via serializer
- migrate database to store poll flexibility
- test updater logic for flexible polls

## Testing
- `bundle exec rspec plugins/poll/spec/lib/polls_updater_spec.rb:176 -fd` *(fails: relation "groups" does not exist)*
- `bundle exec rake db:migrate` *(fails: Interrupt)*

------
https://chatgpt.com/codex/tasks/task_b_685ca090267883248ae2a88b5398fb08