### PR TITLE
Implement one-click unsubscribe support

### DIFF
--- a/app/controllers/email_controller.rb
+++ b/app/controllers/email_controller.rb
@@ -29,7 +29,13 @@ class EmailController < ApplicationController
     key = UnsubscribeKey.includes(:user).find_by(key: params[:key])
     raise Discourse::NotFound if key.nil? || key.user.nil?
     user = key.user
-    updated = UnsubscribeKey.get_unsubscribe_strategy_for(key)&.unsubscribe(params)
+
+    unsubscriber = UnsubscribeKey.get_unsubscribe_strategy_for(key)
+    if (params["List-Unsubscribe"] || params["list-unsubscribe"])&.casecmp?("One-Click")
+      updated = unsubscriber&.unsubscribe(unsubscriber.default_unsubscribe_params)
+    else
+      updated = unsubscriber&.unsubscribe(params)
+    end
 
     if updated
       cache_key = "unsub_#{SecureRandom.hex}"

--- a/lib/email_controller_helper/base_email_unsubscriber.rb
+++ b/lib/email_controller_helper/base_email_unsubscriber.rb
@@ -50,6 +50,10 @@ module EmailControllerHelper
       updated
     end
 
+    def default_unsubscribe_params
+      { unsubscribe_all: "1" }
+    end
+
     protected
 
     def key_owner

--- a/lib/email_controller_helper/digest_email_unsubscriber.rb
+++ b/lib/email_controller_helper/digest_email_unsubscriber.rb
@@ -59,5 +59,9 @@ module EmailControllerHelper
 
       updated
     end
+
+    def default_unsubscribe_params
+      { digest_after_minutes: "0" }
+    end
   end
 end

--- a/lib/email_controller_helper/topic_email_unsubscriber.rb
+++ b/lib/email_controller_helper/topic_email_unsubscriber.rb
@@ -75,5 +75,19 @@ module EmailControllerHelper
 
       updated
     end
+
+    def default_unsubscribe_params
+      topic = unsubscribe_key.associated_topic
+      return { unsubscribe_all: "1" } if topic.nil?
+
+      watching = TopicUser.notification_levels[:watching]
+      is_watching =
+        TopicUser.exists?(user: key_owner, notification_level: watching, topic_id: topic.id)
+      if is_watching
+        { unwatch_topic: "1" }
+      else
+        { mute_topic: "1" }
+      end
+    end
   end
 end

--- a/spec/requests/email_controller_spec.rb
+++ b/spec/requests/email_controller_spec.rb
@@ -45,6 +45,25 @@ RSpec.describe EmailController do
         expect(response.status).to eq(302)
         expect(user.user_option.reload.mailing_list_mode).to eq(false)
       end
+
+      it "supports one-click unsubscribe" do
+        user.user_option.update_columns(
+          email_digests: true,
+          email_level: UserOption.email_level_types[:never],
+          email_messages_level: UserOption.email_level_types[:never],
+          mailing_list_mode: true,
+        )
+
+        post "/email/unsubscribe/#{key}.json", params: { "List-Unsubscribe": "One-Click" }
+
+        expect(response.status).to eq(302)
+        get response.redirect_url
+        expect(body).to include(user.email)
+
+        user.user_option.reload
+        expect(user.user_option.email_digests).to eq(false)
+        expect(user.user_option.mailing_list_mode).to eq(false)
+      end
     end
 
     describe "unsubscribe from digest" do


### PR DESCRIPTION
## Summary
- add default unsubscribe params for each unsubscriber type
- process List-Unsubscribe=One-Click posts
- test one-click unsubscribe

## Testing
- `bundle exec rubocop app/controllers/email_controller.rb lib/email_controller_helper/base_email_unsubscriber.rb lib/email_controller_helper/digest_email_unsubscriber.rb lib/email_controller_helper/topic_email_unsubscriber.rb spec/requests/email_controller_spec.rb`
- `bundle exec stree write Gemfile app/controllers/email_controller.rb lib/email_controller_helper/base_email_unsubscriber.rb lib/email_controller_helper/digest_email_unsubscriber.rb lib/email_controller_helper/topic_email_unsubscriber.rb spec/requests/email_controller_spec.rb`
- `RAILS_ENV=test bundle exec rake db:create db:migrate`
- `bin/rspec spec/requests/email_controller_spec.rb`

------
https://chatgpt.com/codex/tasks/task_b_6860661eca2083249bd3886251faf52b