### PR TITLE
Enhance topic filter UI

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discovery/filter-navigation.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/filter-navigation.gjs
@@ -8,6 +8,7 @@ import { and } from "truth-helpers";
 import BulkSelectToggle from "discourse/components/bulk-select-toggle";
 import DButton from "discourse/components/d-button";
 import PluginOutlet from "discourse/components/plugin-outlet";
+import TopicFilterModal from "discourse/components/topic-filter-modal";
 import bodyClass from "discourse/helpers/body-class";
 import icon from "discourse/helpers/d-icon";
 import lazyHash from "discourse/helpers/lazy-hash";
@@ -17,6 +18,7 @@ import { resettableTracked } from "discourse/lib/tracked-tools";
 
 export default class DiscoveryFilterNavigation extends Component {
   @service site;
+  @service modal;
 
   @tracked copyIcon = "link";
   @tracked copyClass = "btn-default";
@@ -41,6 +43,22 @@ export default class DiscoveryFilterNavigation extends Component {
     navigator.clipboard.writeText(window.location);
 
     discourseDebounce(this._restoreButton, 3000);
+  }
+
+  @action
+  /**
+   * Opens the modal for advanced topic filtering.
+   */
+  openAdvancedModal() {
+    this.modal.show(TopicFilterModal, {
+      model: {
+        currentQuery: this.newQueryString,
+        apply: (query) => {
+          this.updateQueryString(query);
+          this.args.updateTopicsListQueryParams(query);
+        },
+      },
+    });
   }
 
   @bind
@@ -72,6 +90,12 @@ export default class DiscoveryFilterNavigation extends Component {
             @type="text"
             id="queryStringInput"
             autocomplete="off"
+          />
+          <DButton
+            class="btn-transparent topic-query-filter__advanced"
+            @icon="sliders"
+            @title="filters.filter.button.advanced"
+            @action={{this.openAdvancedModal}}
           />
           {{! EXPERIMENTAL OUTLET - don't use because it will be removed soon  }}
           <PluginOutlet

--- a/app/assets/javascripts/discourse/app/components/topic-filter-modal.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-filter-modal.gjs
@@ -1,0 +1,177 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { array, hash } from "@ember/helper";
+import { action } from "@ember/object";
+import { service } from "@ember/service";
+import DButton from "discourse/components/d-button";
+import Form from "discourse/form-kit/components/fk/form";
+import { i18n } from "discourse-i18n";
+import ComboBox from "select-kit/components/combo-box";
+import SearchAdvancedCategoryChooser from "select-kit/components/search-advanced-category-chooser";
+import TagChooser from "select-kit/components/tag-chooser";
+
+/**
+ * Modal for building advanced topic filter queries.
+ *
+ * @component TopicFilterModal
+ * @arg model.currentQuery {string} The current filter query string
+ * @arg model.apply {function} Callback to apply the built query
+ */
+export default class TopicFilterModal extends Component {
+  @service modal;
+
+  /**
+   * API handle provided by FormKit form.
+   *
+   * @type {object}
+   */
+  @tracked formApi;
+
+  get statusOptions() {
+    return [
+      { name: i18n("filters.advanced_filter.status.open"), value: "open" },
+      { name: i18n("filters.advanced_filter.status.closed"), value: "closed" },
+    ];
+  }
+
+  /**
+   * Stores the form API for later manipulation.
+   *
+   * @param {object} api
+   */
+  @action
+  registerApi(api) {
+    this.formApi = api;
+  }
+
+  /**
+   * Updates the form's tag field.
+   *
+   * @param {Array<string>} tags
+   */
+  @action
+  updateTags(tags) {
+    this.formApi.set("tags", tags);
+  }
+
+  /**
+   * Applies the form data to build a query string and
+   * triggers the provided apply callback.
+   *
+   * @param {object} data
+   */
+  @action
+  apply(data) {
+    let query = data.query?.trim() || "";
+    if (data.category) {
+      query = `${query} category:${data.category}`.trim();
+    }
+    if (data.tags?.length) {
+      query = `${query} tags:${data.tags.join(",")}`.trim();
+    }
+    if (data.status) {
+      query = `${query} status:${data.status}`.trim();
+    }
+    if (data.min_posts) {
+      query = `${query} min_posts:${data.min_posts}`.trim();
+    }
+    if (data.max_posts) {
+      query = `${query} max_posts:${data.max_posts}`.trim();
+    }
+    if (data.min_views) {
+      query = `${query} min_views:${data.min_views}`.trim();
+    }
+    if (data.max_views) {
+      query = `${query} max_views:${data.max_views}`.trim();
+    }
+    this.args.model.apply?.(query);
+    this.modal.close();
+  }
+
+  <template>
+    <Form
+      @data={{hash
+        query=this.args.model.currentQuery
+        category=null
+        tags=(array)
+        status=null
+        min_posts=null
+        max_posts=null
+        min_views=null
+        max_views=null
+      }}
+      @onRegisterApi={{this.registerApi}}
+      @onSubmit={{this.apply}}
+      class="topic-filter-modal"
+      as |f|
+    >
+      <f.Field @name="query" @title="filters.filter.button.label" as |field|>
+        <field.Input @type="text" />
+      </f.Field>
+      <f.Field
+        @name="category"
+        @title="filters.advanced_filter.categories"
+        as |field|
+      >
+        <SearchAdvancedCategoryChooser
+          @value={{field.value}}
+          @onChange={{field.set}}
+        />
+      </f.Field>
+      <f.Field @name="tags" @title="filters.advanced_filter.tags" as |field|>
+        <TagChooser
+          @tags={{field.value}}
+          @onChange={{this.updateTags}}
+          @everyTag={{true}}
+          @unlimitedTagCount={{true}}
+        />
+      </f.Field>
+      <f.Field
+        @name="status"
+        @title="filters.advanced_filter.status.label"
+        as |field|
+      >
+        <ComboBox
+          @value={{field.value}}
+          @content={{this.statusOptions}}
+          @onChange={{field.set}}
+        />
+      </f.Field>
+      <f.Field
+        @name="min_posts"
+        @title="filters.advanced_filter.posts.min"
+        as |field|
+      >
+        <field.Input @type="number" />
+      </f.Field>
+      <f.Field
+        @name="max_posts"
+        @title="filters.advanced_filter.posts.max"
+        as |field|
+      >
+        <field.Input @type="number" />
+      </f.Field>
+      <f.Field
+        @name="min_views"
+        @title="filters.advanced_filter.views.min"
+        as |field|
+      >
+        <field.Input @type="number" />
+      </f.Field>
+      <f.Field
+        @name="max_views"
+        @title="filters.advanced_filter.views.max"
+        as |field|
+      >
+        <field.Input @type="number" />
+      </f.Field>
+      <f.Actions>
+        <DButton
+          @label="filters.advanced_filter.apply"
+          @action={{f.submit}}
+          class="btn-primary"
+        />
+      </f.Actions>
+    </Form>
+  </template>
+}

--- a/app/assets/stylesheets/common/components/_index.scss
+++ b/app/assets/stylesheets/common/components/_index.scss
@@ -69,3 +69,4 @@
 @import "dropdown-menu";
 @import "welcome-banner";
 @import "d-multi-select";
+@import "topic-filter-modal";

--- a/app/assets/stylesheets/common/components/topic-filter-modal.scss
+++ b/app/assets/stylesheets/common/components/topic-filter-modal.scss
@@ -1,0 +1,14 @@
+.topic-filter-modal {
+  .d-modal__body {
+    padding: 1em;
+    display: flex;
+    flex-direction: column;
+    gap: 1em;
+  }
+
+  .form-kit__actions {
+    margin-top: 0.5em;
+    display: flex;
+    justify-content: flex-end;
+  }
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3370,7 +3370,7 @@ en:
         hot: "There are no hot topics."
         filter: "There are no topics."
         education:
-          topic_tracking_preferences: "You can view and change your new topic tracking settings in <a href=\"%{basePath}/my/preferences/tracking\">your preferences</a>."
+          topic_tracking_preferences: 'You can view and change your new topic tracking settings in <a href="%{basePath}/my/preferences/tracking">your preferences</a>.'
           unread: "Nothing left unread...impressive!"
           new_new: "Nothing new at the moment...check back soon!"
           new: "Nothing new at the moment...check back soon!"
@@ -4582,6 +4582,22 @@ en:
         title: "Filtered results for %{filter}"
         button:
           label: "Filter"
+          advanced: "Advanced filters"
+      advanced_filter:
+        title: "Advanced Topic Filters"
+        apply: "Apply"
+        categories: "Categories"
+        tags: "Tags"
+        status:
+          label: "Status"
+          open: "Open"
+          closed: "Closed"
+        posts:
+          min: "Min Posts"
+          max: "Max Posts"
+        views:
+          min: "Min Views"
+          max: "Max Views"
       latest:
         title: "Latest"
         title_with_count:


### PR DESCRIPTION
## Summary
- add advanced filter fields for status, post and view counts
- style topic filter modal for a cleaner layout
- document modal API and hook advanced button
- localize new advanced filter labels

## Testing
- `pnpm lint:js app/assets/javascripts/discourse/app/components/discovery/filter-navigation.gjs app/assets/javascripts/discourse/app/components/topic-filter-modal.gjs`
- `pnpm lint:prettier app/assets/stylesheets/common/components/_index.scss app/assets/stylesheets/common/components/topic-filter-modal.scss`


------
https://chatgpt.com/codex/tasks/task_b_68677781948c8324801855938089ed26