### PR TITLE
Use DMenu for filter tips

### DIFF
--- a/app/assets/stylesheets/common/components/filter-tips.scss
+++ b/app/assets/stylesheets/common/components/filter-tips.scss
@@ -1,20 +1,9 @@
-.filter-tips {
-  position: relative;
 
+.filter-tips {
   &__dropdown {
-    position: absolute;
-    top: 100%;
-    left: 0;
-    right: 0;
-    background: var(--secondary);
-    border: 1px solid var(--primary-low);
-    border-radius: var(--d-border-radius);
-    box-shadow: var(--shadow-dropdown);
-    z-index: z("dropdown") + 1;
-    margin-top: 0.25em;
     max-height: 300px;
     overflow-y: auto;
-
+    
     .filter-tip__button {
       display: block;
       width: 100%;


### PR DESCRIPTION
## Summary
- convert filter tips dropdown to use `DMenu`
- update dropdown styles for the new markup

## Testing
- `pnpm lint:js` *(fails: Cannot find module '@discourse/lint-configs')*
- `bundle exec rake qunit:test['/filter-tips']` *(fails: command not found or dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_b_6885785e23b883249890fcc25da0fdc4